### PR TITLE
Fixed systray

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -951,7 +951,7 @@ drawbar(Monitor *m)
 	/* draw status first so it can be overdrawn by tags later */
 	if (m == selmon) { /* status is only drawn on selected monitor */
 		drw_setscheme(drw, scheme[SchemeStatus]);
-		tw = TEXTWM(stext) - lrpad + 2; /* 2px right padding */
+		tw = TEXTWM(stext) - lrpad + stw + 2; /* 2px right padding */
 		drw_text(drw, m->ww - tw, 0, tw, bh, 0, stext, 0, True);
 	}
 
@@ -980,7 +980,7 @@ drawbar(Monitor *m)
 	drw_setscheme(drw, scheme[SchemeTagsNorm]);
 	x = drw_text(drw, x, 0, w, bh, lrpad / 2, m->ltsymbol, 0, False);
 
-	if ((w = m->ww - tw - stw - x) > bh) {
+	if ((w = m->ww - tw - x) > bh) {
 		if (m->sel) {
 			drw_setscheme(drw, scheme[m == selmon ? SchemeInfoSel : SchemeInfoNorm]);
 			drw_text(drw, x, 0, w, bh, lrpad / 2, m->sel->name, 0, False);


### PR DESCRIPTION
The systray was incorrectly displayed when the bar was drawn:

- The systray width was not added to the status text
- The title width was taking into account the systray width that was not correctly displayed because of previous condition

The result was that both the title and the status bars were too short, leading to visual glitches when the screen size changed: neither the title bar nor the status bar was covering the zone corresponding to the systray width on the left of the status bar.

This patch fixes the systray patch by adding the systray width to the status width (`tw`).